### PR TITLE
feat/delivery-batch

### DIFF
--- a/src/main/java/com/coffeeproject/domain/delivery/api/ApiV1DeliveryController.java
+++ b/src/main/java/com/coffeeproject/domain/delivery/api/ApiV1DeliveryController.java
@@ -4,6 +4,7 @@ import com.coffeeproject.domain.delivery.dto.DeliveryDto;
 import com.coffeeproject.domain.delivery.entity.Delivery;
 import com.coffeeproject.domain.delivery.service.DeliveryService;
 import com.coffeeproject.global.rsData.RsData;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
@@ -15,6 +16,7 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/v1/delivery")
 @RequiredArgsConstructor
+@Tag(name = "ApiV1DeliveryController", description = "관리자용 API 배송조회 컨트롤러")
 public class ApiV1DeliveryController {
     private final DeliveryService deliveryService;
     @Transactional

--- a/src/main/java/com/coffeeproject/domain/delivery/api/ApiV1DeliverySchedulerController.java
+++ b/src/main/java/com/coffeeproject/domain/delivery/api/ApiV1DeliverySchedulerController.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("api/vi/admin/scheduler")
+@RequestMapping("api/v1/scheduler")
 @RequiredArgsConstructor
 public class ApiV1DeliverySchedulerController {
     private final DeliverySchedulerService schedulerControlService;

--- a/src/main/java/com/coffeeproject/domain/delivery/api/ApiV1DeliverySchedulerController.java
+++ b/src/main/java/com/coffeeproject/domain/delivery/api/ApiV1DeliverySchedulerController.java
@@ -1,0 +1,28 @@
+package com.coffeeproject.domain.delivery.api;
+
+import com.coffeeproject.domain.delivery.service.DeliverySchedulerService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("api/vi/admin/scheduler")
+@RequiredArgsConstructor
+public class ApiV1DeliverySchedulerController {
+    private final DeliverySchedulerService schedulerControlService;
+
+    /**
+     * Cron표현식을 인자로 받아 해당 주기마다 배치 작업을 수행합니다. 기본값은 "0 0 14 * * ?" 으로 매일 오후2 시입니다.
+     */
+    @GetMapping("/start")
+    public String startDeliveryScheduler(@RequestParam(defaultValue = "0 0 14 * * ?") String cronExpression) {
+        return schedulerControlService.startScheduler(cronExpression);
+    }
+
+    @GetMapping("/stop")
+    public String stopDeliveryScheduler() {
+        return schedulerControlService.stopScheduler();
+    }
+}

--- a/src/main/java/com/coffeeproject/domain/delivery/api/ApiV1DeliverySchedulerController.java
+++ b/src/main/java/com/coffeeproject/domain/delivery/api/ApiV1DeliverySchedulerController.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("api/v1/scheduler")
+@RequestMapping("/api/v1/scheduler")
 @RequiredArgsConstructor
 public class ApiV1DeliverySchedulerController {
     private final DeliverySchedulerService schedulerControlService;

--- a/src/main/java/com/coffeeproject/domain/delivery/entity/Delivery.java
+++ b/src/main/java/com/coffeeproject/domain/delivery/entity/Delivery.java
@@ -11,7 +11,10 @@ import lombok.NoArgsConstructor;
 import java.util.ArrayList;
 import java.util.List;
 
-
+/**
+ * Delivery 엔티티는 주문자의 이메일과 주소가 동일한 List<Order>를 하나로 묶기위한 엔티티 입니다.
+ * 따라서 생성시점에도 필터링을 거쳐 올바른 List<Order>를 전달하여야합니다.
+ */
 @Entity
 @Getter
 @Builder
@@ -31,8 +34,7 @@ public class Delivery extends BaseEntity {
             joinColumns = @JoinColumn(name = "delivery_id"),
             inverseJoinColumns = @JoinColumn(name = "order_id")
     )
-    @Builder.Default
-    private List<Order> orders = new ArrayList<>();
+    private List<Order> orders;
     private int totalPrice;
     @Enumerated(EnumType.STRING)
     private DeliveryStatus status;

--- a/src/main/java/com/coffeeproject/domain/delivery/service/DeliverySchedulerService.java
+++ b/src/main/java/com/coffeeproject/domain/delivery/service/DeliverySchedulerService.java
@@ -1,0 +1,44 @@
+package com.coffeeproject.domain.delivery.service;
+
+import com.coffeeproject.domain.delivery.task.DeliveryBatchTask;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.scheduling.support.CronTrigger;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.ScheduledFuture;
+
+@Service
+@RequiredArgsConstructor
+public class DeliverySchedulerService {
+    private final ThreadPoolTaskScheduler taskScheduler;
+    private final DeliveryBatchTask deliveryBatchTask;
+    private ScheduledFuture<?> scheduledTask;
+
+    /**
+     * 스케줄링 시작 메서드
+     */
+    public String startScheduler(String cronExpression) {
+        if (scheduledTask != null && !scheduledTask.isDone()) {
+            return "스케줄러가 이미 실행 중입니다.";
+        }
+        scheduledTask = taskScheduler.schedule(deliveryBatchTask, new CronTrigger(cronExpression));
+        System.out.println("스케줄러 시작됨.");
+        return "스케줄러가 성공적으로 시작되었습니다.";
+    }
+
+    /**
+     * 스케줄링 중지 메서드
+     * cancel(true)는 현재 실행 중인 태스크를 인터럽트하여 중지시키려고 시도합니다.
+     * false는 현재 실행 중인 태스크는 완료하고 다음 태스크부터 실행하지 않습니다.
+     */
+    public String stopScheduler() {
+        if (scheduledTask != null) {
+            scheduledTask.cancel(true);
+            scheduledTask = null;
+            System.out.println("스케줄러 중지됨.");
+            return "스케줄러가 성공적으로 중지되었습니다.";
+        }
+        return "실행 중인 스케줄러가 없습니다.";
+    }
+}

--- a/src/main/java/com/coffeeproject/domain/delivery/service/DeliverySchedulerService.java
+++ b/src/main/java/com/coffeeproject/domain/delivery/service/DeliverySchedulerService.java
@@ -19,7 +19,7 @@ public class DeliverySchedulerService {
      * 스케줄링 시작 메서드
      */
     public String startScheduler(String cronExpression) {
-        if (scheduledTask != null && !scheduledTask.isDone()) {
+        if (isSchedulerRunning()) {
             return "스케줄러가 이미 실행 중입니다.";
         }
         scheduledTask = taskScheduler.schedule(deliveryBatchTask, new CronTrigger(cronExpression));
@@ -33,12 +33,20 @@ public class DeliverySchedulerService {
      * false는 현재 실행 중인 태스크는 완료하고 다음 태스크부터 실행하지 않습니다.
      */
     public String stopScheduler() {
-        if (scheduledTask != null) {
+        if (isSchedulerRunning()) {
             scheduledTask.cancel(true);
             scheduledTask = null;
             System.out.println("스케줄러 중지됨.");
             return "스케줄러가 성공적으로 중지되었습니다.";
         }
         return "실행 중인 스케줄러가 없습니다.";
+    }
+
+    /**
+     * 스케줄러 실행 상태를 확인하는 메서드
+     * @return 스케줄러 실행 중이면 true, 아니면 false
+     */
+    public boolean isSchedulerRunning() {
+        return scheduledTask != null && !scheduledTask.isDone();
     }
 }

--- a/src/main/java/com/coffeeproject/domain/delivery/service/DeliveryService.java
+++ b/src/main/java/com/coffeeproject/domain/delivery/service/DeliveryService.java
@@ -19,6 +19,7 @@ public class DeliveryService {
                 Delivery.builder()
                         .customerEmail(orderList.getFirst().getCustomerEmail())
                         .shippingAddress(orderList.getFirst().getShippingAddress())
+                        .orders(new ArrayList<>(orderList))
                         .totalPrice(orderList.stream().mapToInt(Order::getTotalPrice).sum())
                         .status(Delivery.DeliveryStatus.PENDING)
                         .build()

--- a/src/main/java/com/coffeeproject/domain/delivery/task/DeliveryBatchTask.java
+++ b/src/main/java/com/coffeeproject/domain/delivery/task/DeliveryBatchTask.java
@@ -13,27 +13,31 @@ import org.springframework.stereotype.Component;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * 스케줄러를 통해 수행될 작업을 정의하는 클래스로 Runnable을 구현합니다.
  */
-@Slf4j
 @Component
 @RequiredArgsConstructor
 public class DeliveryBatchTask implements Runnable {
     private final DeliveryService deliveryService;
     private final OrderService orderService;
 
+    record key(String eMail, String address) {}
+
     @Override
     public void run() {
-        log.info("스케줄링 작업 실행: {}", LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")));
-        //1. 단 배송해야할 오더의 리스트를 반환한다.
-        List<Order> list = orderService.getAllOrders().stream()
+        Map<key, List<Order>> orders = orderService.getAllOrders().stream()
                 .filter(order -> order.getStatus() == OrderStatus.PAID)
                 .filter(order -> order.getCreateDate().isAfter(LocalDateTime.now().minusHours(24)))
-                .toList();
-        //2. 배송 엔티티로 만들어 저장한다.
-        //FIXME : 이건 잘못된 사용법. 주문자와 주소가 동일한 Order끼리만 리스트로 만들어서 생성해야함
-        Delivery delivery = deliveryService.createDelivery(list);
+                .collect(Collectors.groupingBy(
+                        order -> new key(order.getCustomerEmail(), order.getShippingAddress())
+                ));
+
+        for (List<Order> order : orders.values()) {
+            deliveryService.createDelivery(order);
+        }
     }
 }

--- a/src/main/java/com/coffeeproject/domain/delivery/task/DeliveryBatchTask.java
+++ b/src/main/java/com/coffeeproject/domain/delivery/task/DeliveryBatchTask.java
@@ -1,0 +1,26 @@
+package com.coffeeproject.domain.delivery.task;
+
+import com.coffeeproject.domain.delivery.service.DeliveryService;
+import com.coffeeproject.domain.order.order.service.OrderService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * 스케줄러를 통해 수행될 작업을 정의하는 클래스로 Runnable을 구현합니다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DeliveryBatchTask implements Runnable {
+    private final DeliveryService deliveryService;
+    private final OrderService orderService;
+
+    @Override
+    public void run() {
+        log.info("스케줄링 작업 실행: {}", LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")));
+    }
+}

--- a/src/main/java/com/coffeeproject/domain/delivery/task/DeliveryBatchTask.java
+++ b/src/main/java/com/coffeeproject/domain/delivery/task/DeliveryBatchTask.java
@@ -1,13 +1,18 @@
 package com.coffeeproject.domain.delivery.task;
 
+import com.coffeeproject.domain.delivery.entity.Delivery;
 import com.coffeeproject.domain.delivery.service.DeliveryService;
+import com.coffeeproject.domain.order.order.entity.Order;
+import com.coffeeproject.domain.order.order.enums.OrderStatus;
 import com.coffeeproject.domain.order.order.service.OrderService;
+import com.coffeeproject.domain.order.orderitem.OrderItem;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.List;
 
 /**
  * 스케줄러를 통해 수행될 작업을 정의하는 클래스로 Runnable을 구현합니다.
@@ -22,5 +27,13 @@ public class DeliveryBatchTask implements Runnable {
     @Override
     public void run() {
         log.info("스케줄링 작업 실행: {}", LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")));
+        //1. 단 배송해야할 오더의 리스트를 반환한다.
+        List<Order> list = orderService.getAllOrders().stream()
+                .filter(order -> order.getStatus() == OrderStatus.PAID)
+                .filter(order -> order.getCreateDate().isAfter(LocalDateTime.now().minusHours(24)))
+                .toList();
+        //2. 배송 엔티티로 만들어 저장한다.
+        //FIXME : 이건 잘못된 사용법. 주문자와 주소가 동일한 Order끼리만 리스트로 만들어서 생성해야함
+        Delivery delivery = deliveryService.createDelivery(list);
     }
 }

--- a/src/main/java/com/coffeeproject/global/scheduler/SchedulerConfig.java
+++ b/src/main/java/com/coffeeproject/global/scheduler/SchedulerConfig.java
@@ -1,0 +1,18 @@
+package com.coffeeproject.global.scheduler;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+@Configuration
+public class SchedulerConfig {
+
+    @Bean
+    public ThreadPoolTaskScheduler taskScheduler() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(10);
+        scheduler.setThreadNamePrefix("my-scheduler-");
+        scheduler.initialize();
+        return scheduler;
+    }
+}

--- a/src/test/java/com/coffeeproject/domain/delivery/api/ApiV1DeliveryControllerTest.java
+++ b/src/test/java/com/coffeeproject/domain/delivery/api/ApiV1DeliveryControllerTest.java
@@ -66,8 +66,8 @@ public class ApiV1DeliveryControllerTest {
                 .totalPrice(20000)
                 .build();
 
-        deliveryService.createDelivery(Arrays.asList(order1)); //
-        deliveryService.createDelivery(Arrays.asList(order2, order3)); //
+        deliveryService.createDelivery(Arrays.asList(order1)); 
+        deliveryService.createDelivery(Arrays.asList(order2, order3)); 
     }
 
     @Test
@@ -77,7 +77,7 @@ public class ApiV1DeliveryControllerTest {
                 .perform(get("/api/v1/delivery"))
                 .andDo(print());
 
-        List<Delivery> allDeliveries = deliveryService.getAllDeliveries(); //
+        List<Delivery> allDeliveries = deliveryService.getAllDeliveries(); 
 
         resultActions
                 .andExpect(handler().handlerType(ApiV1DeliveryController.class))
@@ -102,7 +102,7 @@ public class ApiV1DeliveryControllerTest {
     @DisplayName("배송 정보 단건 조회")
     void t2() throws Exception {
         Delivery existingDelivery = deliveryService.getAllDeliveries().getFirst();
-        int deliveryId = existingDelivery.getId(); //
+        int deliveryId = existingDelivery.getId(); 
 
         ResultActions resultActions = mvc
                 .perform(get("/api/v1/delivery/" + deliveryId))

--- a/src/test/java/com/coffeeproject/domain/delivery/api/ApiV1DeliverySchedulerControllerTest.java
+++ b/src/test/java/com/coffeeproject/domain/delivery/api/ApiV1DeliverySchedulerControllerTest.java
@@ -1,0 +1,4 @@
+import static org.junit.jupiter.api.Assertions.*;
+class ApiV1DeliverySchedulerControllerTest {
+  
+}

--- a/src/test/java/com/coffeeproject/domain/delivery/api/ApiV1DeliverySchedulerControllerTest.java
+++ b/src/test/java/com/coffeeproject/domain/delivery/api/ApiV1DeliverySchedulerControllerTest.java
@@ -1,4 +1,168 @@
-import static org.junit.jupiter.api.Assertions.*;
+package com.coffeeproject.domain.delivery.api;
+
+import com.coffeeproject.domain.delivery.entity.Delivery;
+import com.coffeeproject.domain.delivery.repository.DeliveryRepository;
+import com.coffeeproject.domain.delivery.service.DeliverySchedulerService;
+import com.coffeeproject.domain.delivery.task.DeliveryBatchTask;
+import com.coffeeproject.domain.order.order.entity.Order;
+import com.coffeeproject.domain.order.order.enums.OrderStatus;
+import com.coffeeproject.domain.order.order.repository.OrderRepository;
+import com.coffeeproject.global.jpa.entity.BaseEntity;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.lang.reflect.Field;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ActiveProfiles("test")
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
 class ApiV1DeliverySchedulerControllerTest {
-  
+    @Autowired
+    private MockMvc mvc;
+
+    @Autowired
+    private DeliverySchedulerService deliverySchedulerService;
+
+    @Autowired
+    private DeliveryRepository deliveryRepository;
+
+    @Autowired
+    private OrderRepository orderRepository;
+
+    @Autowired
+    private DeliveryBatchTask deliveryBatchTask;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        deliveryRepository.deleteAll();
+        orderRepository.deleteAll();
+
+        Order order1 = Order.builder()
+                .customerEmail("user1@example.com")
+                .shippingAddress("서울시 강남구")
+                .totalPrice(15000)
+                .status(OrderStatus.PAID)
+                .build();
+        setCreateDate(order1, LocalDateTime.now());
+
+        Order order2 = Order.builder()
+                .customerEmail("user2@example.com")
+                .shippingAddress("부산시 해운대구")
+                .totalPrice(20000)
+                .status(OrderStatus.PAID)
+                .build();
+        setCreateDate(order2, LocalDateTime.now());
+
+        Order order3 = Order.builder()
+                .customerEmail("user2@example.com")
+                .shippingAddress("부산시 해운대구")
+                .totalPrice(20000)
+                .status(OrderStatus.PAID)
+                .build();
+        setCreateDate(order3, LocalDateTime.now());
+
+        orderRepository.saveAll(Arrays.asList(order1, order2, order3));
+    }
+
+    private void setCreateDate(Order order, LocalDateTime date) throws Exception {
+        Field createDateField = BaseEntity.class.getDeclaredField("createDate");
+        createDateField.setAccessible(true);
+        createDateField.set(order, date);
+    }
+
+    @Test
+    @DisplayName("엔드포인트로 시작 요청시 기본값으로 실행되는지")
+    void schedulerStartTest() throws Exception {
+        ResultActions resultActions = mvc
+                .perform(get("/api/v1/scheduler/start"))
+                .andDo(print());
+
+        resultActions
+                .andExpect(status().isOk());
+
+        assertThat(deliverySchedulerService.isSchedulerRunning()).isTrue();
+    }
+
+    @Test
+    @DisplayName("엔드포인트로 시작 요청시 요청한 Cron표현식에 따라 실행되는지")
+    void schedulerStartTestWithCronExpression() throws Exception {
+        String cronExpression = "0 0/5 * * * ?";
+
+        ResultActions resultActions = mvc
+                .perform(get("/api/v1/scheduler/start")
+                        .param("cronExpression", cronExpression))
+                .andDo(print());
+
+        resultActions
+                .andExpect(status().isOk());
+
+        assertThat(deliverySchedulerService.isSchedulerRunning()).isTrue();
+    }
+
+    @Test
+    @DisplayName("엔드포인트로 종료 요청시 종료되는지")
+    void schedulerStopTest() throws Exception {
+        deliverySchedulerService.startScheduler("0 0 0 * * ?");
+        assertThat(deliverySchedulerService.isSchedulerRunning()).isTrue();
+
+        ResultActions resultActions = mvc
+                .perform(get("/api/v1/scheduler/stop"))
+                .andDo(print());
+
+        resultActions
+                .andExpect(status().isOk());
+
+        assertThat(deliverySchedulerService.isSchedulerRunning()).isFalse();
+    }
+
+    @Test
+    @DisplayName("배치로 딜리버리 엔티티 생기는지 총액 및 다른 필드는 정확하게 들어가는지 확인")
+    void deliveryCreationTest() {
+        deliveryBatchTask.run();
+
+        List<Delivery> deliveries = deliveryRepository.findAll();
+        assertThat(deliveries).hasSize(2);
+
+        Delivery user1Delivery = deliveries.stream()
+                .filter(d -> d.getCustomerEmail().equals("user1@example.com"))
+                .findFirst()
+                .orElse(null);
+
+        assertThat(user1Delivery).isNotNull();
+        assertThat(user1Delivery.getShippingAddress()).isEqualTo("서울시 강남구");
+        assertThat(user1Delivery.getStatus()).isEqualTo(Delivery.DeliveryStatus.PENDING);
+        assertThat(user1Delivery.getOrders()).hasSize(1);
+        assertThat(user1Delivery.getOrders().getFirst().getTotalPrice()).isEqualTo(15000);
+
+        Delivery user2Delivery = deliveries.stream()
+                .filter(d -> d.getCustomerEmail().equals("user2@example.com"))
+                .findFirst()
+                .orElse(null);
+
+        assertThat(user2Delivery).isNotNull();
+        assertThat(user2Delivery.getShippingAddress()).isEqualTo("부산시 해운대구");
+        assertThat(user2Delivery.getStatus()).isEqualTo(Delivery.DeliveryStatus.PENDING);
+        assertThat(user2Delivery.getOrders()).hasSize(2);
+
+        int totalForUser2 = user2Delivery.getOrders().stream().mapToInt(Order::getTotalPrice).sum();
+        assertThat(totalForUser2).isEqualTo(40000);
+    }
 }


### PR DESCRIPTION
## 📌 과제 설명
실행시점에서 24시간 이내에 생성된 `Order` 엔티티 들을 검사하여 `Delivery`  엔티티로 변경할 수 있도록 하였습니다.

## 👩‍💻 요구 사항과 구현 내용
`/api/v1/scheduler`를 통해 스케줄러가 실행요청이 오면 `DeliverySchedulerService.startScheduler()`를 통해 `DeliveryBatchTask`가 실행됩니다.

별도의 실행계획이 Cron표현식으로 전달되지 않으면 낮 12시에 실행됩니다.

`DeliveryBatchTask`는 모든 `Order`를 조회, 결제가 완료되고 24시간 안에 생성된 `Order`만을 필터링 하며 주문자 이메일과 주소를 복합키로 그루핑한 `Map<key, List<Order>>` 을 반환합니다.

반환된 콜랙션을 순회하며 `deliveryService.createDelivery(order);` 를 실행합니다.

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->

close#18
