### PR TITLE
[BE] 주문 생성 로직 변경 및 결제 API 구현

### DIFF
--- a/src/main/java/com/coffeeproject/domain/order/order/controller/ApiV1OrderController.java
+++ b/src/main/java/com/coffeeproject/domain/order/order/controller/ApiV1OrderController.java
@@ -67,4 +67,22 @@ public class ApiV1OrderController {
                 new OrderResponse(order)
         );
     }
+
+    @PostMapping("/{id}/payment/complete")
+    public RsData<OrderResponse> completePayment(@PathVariable(value = "id") int id) {
+        Order order = orderService.completePayment(id);
+        return new RsData<>("200",
+                "결제가 완료되었습니다.",
+                new OrderResponse(order)
+        );
+    }
+
+    @PostMapping("/{id}/payment/cancel")
+    public RsData<OrderResponse> cancelPayment(@PathVariable(value = "id") int id) {
+        Order order = orderService.cancelPayment(id);
+        return new RsData<>("200",
+                "결제가 취소되었습니다.",
+                new OrderResponse(order)
+        );
+    }
 }

--- a/src/main/java/com/coffeeproject/domain/order/order/dto/OrderResponse.java
+++ b/src/main/java/com/coffeeproject/domain/order/order/dto/OrderResponse.java
@@ -1,6 +1,7 @@
 package com.coffeeproject.domain.order.order.dto;
 
 import com.coffeeproject.domain.order.order.entity.Order;
+import com.coffeeproject.domain.order.order.enums.OrderStatus;
 import com.coffeeproject.domain.order.orderitem.dto.OrderItemResponse;
 
 import java.util.List;
@@ -11,6 +12,7 @@ public record OrderResponse(
         String shippingAddress,
         String shippingZipCode,
         int totalPrice,
+        OrderStatus status,
         List<OrderItemResponse> items
 ) {
     public OrderResponse(Order order) {
@@ -20,6 +22,7 @@ public record OrderResponse(
                 order.getShippingAddress(),
                 order.getShippingZipCode(),
                 order.getTotalPrice(),
+                order.getStatus(),
                 order.getOrderItems()
                         .stream()
                         .map(OrderItemResponse::new)

--- a/src/main/java/com/coffeeproject/domain/order/order/entity/Order.java
+++ b/src/main/java/com/coffeeproject/domain/order/order/entity/Order.java
@@ -2,6 +2,7 @@ package com.coffeeproject.domain.order.order.entity;
 
 import com.coffeeproject.domain.order.order.enums.OrderStatus;
 import com.coffeeproject.domain.order.orderitem.OrderItem;
+import com.coffeeproject.global.exception.ServiceException;
 import com.coffeeproject.global.jpa.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -63,5 +64,16 @@ public class Order extends BaseEntity {
 
     public void updateStatus(OrderStatus status) {
         this.status = status;
+    }
+
+    public void paid() {
+        if (this.status != OrderStatus.PENDING) {
+            throw new ServiceException("400", "결제 대기 상태에서만 결제 완료 처리가 가능합니다. 현재 상태: " + status);
+        }
+        this.status = OrderStatus.PAID;
+    }
+
+    public void cancel() {
+        this.status = OrderStatus.CANCELED;
     }
 }

--- a/src/main/java/com/coffeeproject/domain/order/order/entity/Order.java
+++ b/src/main/java/com/coffeeproject/domain/order/order/entity/Order.java
@@ -38,7 +38,7 @@ public class Order extends BaseEntity {
         this.customerEmail = customerEmail;
         this.shippingAddress = shippingAddress;
         this.shippingZipCode = shippingZipCode;
-        this.status = OrderStatus.PAID;
+        this.status = OrderStatus.PENDING;
     }
 
     public static Order createOrder(String customerEmail, String shippingAddress, String shippingZipCode) {

--- a/src/main/java/com/coffeeproject/domain/order/order/enums/OrderStatus.java
+++ b/src/main/java/com/coffeeproject/domain/order/order/enums/OrderStatus.java
@@ -4,6 +4,7 @@ import lombok.Getter;
 
 @Getter
 public enum OrderStatus {
+    PENDING("결제 전"),
     PAID("결제 완료"),
     CANCELED("결제 취소");
 

--- a/src/main/java/com/coffeeproject/domain/order/order/service/OrderService.java
+++ b/src/main/java/com/coffeeproject/domain/order/order/service/OrderService.java
@@ -1,6 +1,7 @@
 package com.coffeeproject.domain.order.order.service;
 
 import com.coffeeproject.domain.order.order.entity.Order;
+import com.coffeeproject.domain.order.order.enums.OrderStatus;
 import com.coffeeproject.domain.order.order.repository.OrderRepository;
 import com.coffeeproject.domain.order.order.service.dto.OrderCreateServiceRequest;
 import com.coffeeproject.domain.order.order.service.dto.OrderUpdateServiceRequest;
@@ -66,6 +67,20 @@ public class OrderService {
         order.calculateTotalAmount();
 
         return order;
+    }
+
+    @Transactional
+    public Order completePayment(int orderId) {
+        Order order = findOrderById(orderId);
+        order.paid();
+        return orderRepository.save(order);
+    }
+
+    @Transactional
+    public Order cancelPayment(int orderId) {
+        Order order = findOrderById(orderId);
+        order.cancel();
+        return orderRepository.save(order);
     }
 
     private void addOrderItems(Order order, List<OrderCreateServiceRequest.OrderItemServiceRequest> itemRequests) {

--- a/src/test/java/com/coffeeproject/domain/order/order/controller/ApiV1OrderControllerTest.java
+++ b/src/test/java/com/coffeeproject/domain/order/order/controller/ApiV1OrderControllerTest.java
@@ -235,4 +235,32 @@ class ApiV1OrderControllerTest {
                 .andExpect(jsonPath("$.resultCode").value("400-1"))
                 .andExpect(jsonPath("$.msg").value(containsString("필수입니다.")));
     }
+
+    @Test
+    @DisplayName("결제 완료 성공")
+    void completePayment() throws Exception {
+        Order order = orderService.createOrder(request.toServiceRequest());
+        em.flush();
+        em.clear();
+
+        mockMvc.perform(post("/api/v1/orders/{id}/payment/complete", order.getId())
+                        .contentType(String.valueOf(MediaType.APPLICATION_JSON)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.resultCode").value("200"))
+                .andExpect(jsonPath("$.msg").value("결제가 완료되었습니다."))
+                .andExpect(jsonPath("$.data.status").value("PAID"));
+    }
+
+    @Test
+    @DisplayName("결제 취소 성공")
+    void cancelPayment() throws Exception {
+        Order order = orderService.createOrder(request.toServiceRequest());
+
+        mockMvc.perform(post("/api/v1/orders/{id}/payment/cancel", order.getId())
+                        .contentType(String.valueOf(MediaType.APPLICATION_JSON)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.resultCode").value("200"))
+                .andExpect(jsonPath("$.msg").value("결제가 취소되었습니다."))
+                .andExpect(jsonPath("$.data.status").value("CANCELED"));
+    }
 }


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
주문 생성 시 상태 PENDING("결제 전")으로 변경하였습니다.
/api/v1/orders/{id}/payment/complete : 결제 완료 API를 추가하였습니다. (상태가 결제 전이라면 결제 완료 상태로 변경합니다.)
/api/v1/orders/{id}/payment/cancel : 결제 취소 API를 추가하였습니다. (상태를 결제 취소 상태로 변경합니다.)
성공 테스트 케이스를 구현하였습니다.

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->

## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
